### PR TITLE
Updated all examples to use unbundled version of nap

### DIFF
--- a/basic/basic.html
+++ b/basic/basic.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
+  <script type="text/javascript" src="../node_modules/@websdk/rhumb/lib/rhumb.js"></script>
   <script type="text/javascript" src="../node_modules/@websdk/nap/lib/nap.js"></script>
   <script type="text/javascript" src="../node_modules/d3/d3.js"></script>
   

--- a/basic/bodies.html
+++ b/basic/bodies.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
+  <script type="text/javascript" src="../node_modules/@websdk/rhumb/lib/rhumb.js"></script>
   <script type="text/javascript" src="../node_modules/@websdk/nap/lib/nap.js"></script>
   <script type="text/javascript" src="../node_modules/d3/d3.js"></script>
   

--- a/basic/middleware.html
+++ b/basic/middleware.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
+  <script type="text/javascript" src="../node_modules/@websdk/rhumb/lib/rhumb.js"></script>
   <script type="text/javascript" src="../node_modules/@websdk/nap/lib/nap.js"></script>
   <script type="text/javascript" src="../node_modules/d3/d3.js"></script>
   

--- a/basic/names.html
+++ b/basic/names.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
+  <script type="text/javascript" src="../node_modules/@websdk/rhumb/lib/rhumb.js"></script>
   <script type="text/javascript" src="../node_modules/@websdk/nap/lib/nap.js"></script>
   <script type="text/javascript" src="../node_modules/d3/d3.js"></script>
   

--- a/basic/navigation.html
+++ b/basic/navigation.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
+  <script type="text/javascript" src="../node_modules/@websdk/rhumb/lib/rhumb.js"></script>
   <script type="text/javascript" src="../node_modules/@websdk/nap/lib/nap.js"></script>
   <script type="text/javascript" src="../node_modules/d3/d3.js"></script>
   

--- a/basic/negotiate.html
+++ b/basic/negotiate.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
+  <script type="text/javascript" src="../node_modules/@websdk/rhumb/lib/rhumb.js"></script>
   <script type="text/javascript" src="../node_modules/@websdk/nap/lib/nap.js"></script>
   <script type="text/javascript" src="../node_modules/d3/d3.js"></script>
   

--- a/basic/requirejs.html
+++ b/basic/requirejs.html
@@ -6,16 +6,12 @@
   <script type="text/javascript">
     var require = {
       paths: {
-        "nap": "../node_modules/@websdk/nap/lib/nap"
+        "@websdk/rhumb": "../node_modules/@websdk/rhumb/lib/rhumb"
+      , "@websdk/nap": "../node_modules/@websdk/nap/lib/nap"
       , "d3": "../node_modules/d3/d3"
       }
     , shim: {
-        "nap": {
-          exports: "nap"  
-        }
-      , "d3": {
-          exports: "d3"
-        }
+        "d3": { exports: "d3" }
       }
     }
   </script>
@@ -25,7 +21,7 @@
   <script type="text/javascript">
     define(
       "example"
-    , [ "nap"
+    , [ "@websdk/nap"
       , "d3"
       ]
     , function(nap, d3) {

--- a/basic/views.html
+++ b/basic/views.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
+  <script type="text/javascript" src="../node_modules/@websdk/rhumb/lib/rhumb.js"></script>
   <script type="text/javascript" src="../node_modules/@websdk/nap/lib/nap.js"></script>
   <script type="text/javascript" src="../node_modules/d3/d3.js"></script>
   

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.1",
   "description": "Examples of how to use @websdk/nap",
   "dependencies": {
-    "@websdk/nap": "0.9.7",
+    "@websdk/nap": "0.9.8",
+    "@websdk/rhumb": "0.3.4",
     "d3": "3.5.6"
   },
   "repository": {


### PR DESCRIPTION
This means having to explicitly declare rhumb as a dependency,
since it's no longer bundled with nap. The examples are contrived
anyway, so the fact that this is both a chore to maintain and an
eyesore is just a poke to say that we need better examples.
